### PR TITLE
Ensure bootstrap script runs after coreos upgrade

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -7,7 +7,7 @@ mkdir -p $BINDIR
 
 cd $BINDIR
 
-if [[ -e $BINDIR/.bootstrapped && -f $BINDIR/pypy/lib/libtinfo.so.5 ]]; then
+if [[ -e $BINDIR/.bootstrapped && -L $BINDIR/pypy/lib/libtinfo.so.5 ]]; then
   exit 0
 fi
 

--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -7,7 +7,7 @@ mkdir -p $BINDIR
 
 cd $BINDIR
 
-if [[ -e $BINDIR/.bootstrapped ]]; then
+if [[ -e $BINDIR/.bootstrapped && -f $BINDIR/pypy/lib/libtinfo.so.5 ]]; then
   exit 0
 fi
 

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -1,6 +1,6 @@
 ---
 - name: Bootstrap | Check if bootstrap is needed
-  raw: stat /opt/bin/.bootstrapped
+  raw: stat /opt/bin/.bootstrapped && test -e /opt/bin/pypy/lib/libtinfo.so.5
   register: need_bootstrap
   environment: {}
   failed_when: false


### PR DESCRIPTION
This will need to be cleaned up a little before we could get it
upstreamed. Probably what we would need to do is remove the modification
from bootstrap.sh and add additional tasks to remove the
$BINDIR/.bootstrapped if the expected file doesn't exist.