### PR TITLE
K8S-2128 - Change cinder storage class name to be openstack

### DIFF
--- a/roles/kubernetes-apps/persistent_volumes/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 persistent_volumes_enabled: false
 storage_classes:
-  - name: standard
+  - name: openstack
     is_default: true
     parameters:
       availability: nova


### PR DESCRIPTION
In kaasctl, the default storage class is called standard. To maintain compatibility, it should be called "openstack" per JIRA: https://rpc-openstack.atlassian.net/browse/K8S-2128