### PR TITLE
Updates to support openstack inventory plugin and custom inventory group sort when selecting first kube-master, kube-node, or etcd hosts

### DIFF
--- a/contrib/metallb/roles/provision/tasks/main.yml
+++ b/contrib/metallb/roles/provision/tasks/main.yml
@@ -5,7 +5,7 @@
   with_items: ["metallb.yml", "metallb-config.yml"]
   register: "rendering"
   when:
-    - "inventory_hostname == groups['kube-master'][0]"
+    - "inventory_hostname == first_kube_master_host"
 - name: "Kubernetes Apps | Install and configure MetalLB"
   kube:
     name: "MetalLB"
@@ -14,4 +14,4 @@
     state: "{{ item.changed | ternary('latest','present') }}"
   with_items: "{{ rendering.results }}"
   when:
-    - "inventory_hostname == groups['kube-master'][0]"
+    - "inventory_hostname == first_kube_master_host"

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -218,6 +218,10 @@ resource "openstack_compute_instance_v2" "etcd" {
     depends_on       = "${var.network_id}"
   }
 
+  provisioner "local-exec" {
+    command = "mkdir -p ${var.inventory_dir}/host_vars/${self.name}/ && echo 'ansible_ssh_host: ${self.access_ip_v4}' > ${var.inventory_dir}/host_vars/${self.name}/ansible_ssh_host.yml"
+  }
+
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
@@ -250,6 +254,10 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
     depends_on       = "${var.network_id}"
   }
 
+  provisioner "local-exec" {
+    command = "mkdir -p ${var.inventory_dir}/host_vars/${self.name}/ && echo 'ansible_ssh_host: ${self.access_ip_v4}' > ${var.inventory_dir}/host_vars/${self.name}/ansible_ssh_host.yml"
+  }
+
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
@@ -279,6 +287,10 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
     kubespray_groups = "kube-master,${var.supplementary_master_groups},k8s-cluster,vault,no-floating" # use of kubespray_groups is deprecated; use 'groups' instead
     groups = "kube-master,${var.supplementary_master_groups},k8s-cluster,vault,no-floating"
     depends_on       = "${var.network_id}"
+  }
+
+  provisioner "local-exec" {
+    command = "mkdir -p ${var.inventory_dir}/host_vars/${self.name}/ && echo 'ansible_ssh_host: ${self.access_ip_v4}' > ${var.inventory_dir}/host_vars/${self.name}/ansible_ssh_host.yml"
   }
 
 }
@@ -342,6 +354,10 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
     depends_on       = "${var.network_id}"
   }
 
+  provisioner "local-exec" {
+    command = "mkdir -p ${var.inventory_dir}/host_vars/${self.name}/ && echo 'ansible_ssh_host: ${self.access_ip_v4}' > ${var.inventory_dir}/host_vars/${self.name}/ansible_ssh_host.yml"
+  }
+
 }
 
 resource "openstack_compute_floatingip_associate_v2" "bastion" {
@@ -398,6 +414,10 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
     kubespray_groups = "gfs-cluster,network-storage,no-floating" # use of kubespray_groups is deprecated; use 'groups' instead
     groups = "gfs-cluster,network-storage,no-floating"
     depends_on       = "${var.network_id}"
+  }
+
+  provisioner "local-exec" {
+    command = "mkdir -p ${var.inventory_dir}/host_vars/${self.name}/ && echo 'ansible_ssh_host: ${self.access_ip_v4}' > ${var.inventory_dir}/host_vars/${self.name}/ansible_ssh_host.yml"
   }
 
 }

--- a/contrib/vault/roles/vault/tasks/shared/check_etcd.yml
+++ b/contrib/vault/roles/vault/tasks/shared/check_etcd.yml
@@ -11,7 +11,7 @@
   until: vault_etcd_health_check.status == 200 or vault_etcd_health_check.status == 401
   retries: 3
   delay: 2
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ first_etcd_host }}"
   run_once: true
   failed_when: false
   register: vault_etcd_health_check

--- a/roles/bastion-ssh-config/tasks/main.yml
+++ b/roles/bastion-ssh-config/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    bastion_ip: "{{ hostvars[groups['bastion'][0]]['ansible_host'] | d(hostvars[groups['bastion'][0]]['ansible_ssh_host']) }}"
+    bastion_ip: "{{ hostvars[first_bastion_host]['ansible_host'] | d(hostvars[first_bastion_host]['ansible_ssh_host']) }}"
   delegate_to: localhost
 
 # As we are actually running on localhost, the ansible_ssh_user is your local user when you try to use it directly

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -59,7 +59,7 @@
   with_items:
     - "dnsmasq-clusterrolebinding.yml"
     - "dnsmasq-serviceaccount.yml"
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Apply dnsmasq RBAC manifests
@@ -67,7 +67,7 @@
   with_items:
     - "dnsmasq-clusterrolebinding.yml"
     - "dnsmasq-serviceaccount.yml"
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Create dnsmasq manifests
@@ -79,7 +79,7 @@
     - {name: dnsmasq, file: dnsmasq-svc.yml, type: svc}
     - {name: dnsmasq-autoscaler, file: dnsmasq-autoscaler.yml, type: deployment}
   register: manifests
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Start Resources
@@ -91,7 +91,7 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ manifests.results }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Check for dnsmasq port (pulling image and running container)
@@ -99,4 +99,4 @@
     host: "{{dnsmasq_dns_server}}"
     port: 53
     timeout: 180
-  when: inventory_hostname == groups['kube-node'][0] and groups['kube-node'][0] in ansible_play_hosts
+  when: inventory_hostname == first_kube_worker_host and first_kube_worker_host in ansible_play_hosts

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -29,7 +29,7 @@ download_always_pull: False
 download_validate_certs: True
 
 # Use the first kube-master if download_localhost is not set
-download_delegate: "{% if download_localhost %}localhost{% else %}{{groups['kube-master'][0]}}{% endif %}"
+download_delegate: "{% if download_localhost %}localhost{% else %}{{ first_kube_master_host }}{% endif %}"
 
 # Arch of Docker images and needed packages
 image_arch: "{{host_architecture | default('amd64')}}"

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -4,7 +4,7 @@
     paths: "{{ etcd_cert_dir }}"
     patterns: "ca.pem,node*.pem"
     get_checksum: true
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ first_etcd_host }}"
   register: etcdcert_master
   run_once: true
 

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -8,17 +8,17 @@
     mode: 0700
     recurse: yes
 
-- name: "Gen_certs | create etcd script dir (on {{groups['etcd'][0]}})"
+- name: "Gen_certs | create etcd script dir (on {{first_etcd_host}})"
   file:
     path: "{{ etcd_script_dir }}"
     state: directory
     owner: root
     mode: 0700
   run_once: yes
-  when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{groups['etcd'][0]}}"
+  when: inventory_hostname == first_etcd_host
+  delegate_to: "{{first_etcd_host}}"
 
-- name: "Gen_certs | create etcd cert dir (on {{groups['etcd'][0]}})"
+- name: "Gen_certs | create etcd cert dir (on {{first_etcd_host}})"
   file:
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"
@@ -27,18 +27,18 @@
     recurse: yes
     mode: 0700
   run_once: yes
-  when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{groups['etcd'][0]}}"
+  when: inventory_hostname == first_etcd_host
+  delegate_to: "{{first_etcd_host}}"
 
 - name: Gen_certs | write openssl config
   template:
     src: "openssl.conf.j2"
     dest: "{{ etcd_config_dir }}/openssl.conf"
   run_once: yes
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{first_etcd_host}}"
   when:
     - gen_certs|default(false)
-    - inventory_hostname == groups['etcd'][0]
+    - inventory_hostname == first_etcd_host
 
 - name: Gen_certs | copy certs generation script
   template:
@@ -46,10 +46,10 @@
     dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
     mode: 0700
   run_once: yes
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{first_etcd_host}}"
   when:
     - gen_certs|default(false)
-    - inventory_hostname == groups['etcd'][0]
+    - inventory_hostname == first_etcd_host
 
 - name: Gen_certs | run cert generation script
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
@@ -65,10 +65,10 @@
                 {% endif %}
               {% endfor %}"
   run_once: yes
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{first_etcd_host}}"
   when:
     - gen_certs|default(false)
-    - inventory_hostname == groups['etcd'][0]
+    - inventory_hostname == first_etcd_host
   notify: set etcd_secret_changed
 
 - name: Gen_certs | Gather etcd master certs
@@ -88,11 +88,11 @@
         '{{ etcd_cert_dir }}/node-{{ node }}.pem',
         '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
         {% endfor %}]"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{first_etcd_host}}"
   when:
     - inventory_hostname in groups['etcd']
     - sync_certs|default(false)
-    - inventory_hostname != groups['etcd'][0]
+    - inventory_hostname != first_etcd_host
   notify: set etcd_secret_changed
 
 - name: Gen_certs | Write etcd master certs
@@ -106,7 +106,7 @@
   when:
     - inventory_hostname in groups['etcd']
     - sync_certs|default(false)
-    - inventory_hostname != groups['etcd'][0]
+    - inventory_hostname != first_etcd_host
   loop_control:
     label: "{{ item.item }}"
 
@@ -134,7 +134,7 @@
   no_log: true
   register: etcd_node_certs
   check_mode: no
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{first_etcd_host}}"
   when: (('calico-rr' in groups and inventory_hostname in groups['calico-rr']) or
         inventory_hostname in groups['k8s-cluster']) and
         sync_certs|default(false) and inventory_hostname not in groups['etcd']

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -14,9 +14,7 @@
     state: directory
     owner: root
     mode: 0700
-  run_once: yes
   when: inventory_hostname == first_etcd_host
-  delegate_to: "{{first_etcd_host}}"
 
 - name: "Gen_certs | create etcd cert dir (on {{first_etcd_host}})"
   file:
@@ -26,16 +24,12 @@
     owner: kube
     recurse: yes
     mode: 0700
-  run_once: yes
   when: inventory_hostname == first_etcd_host
-  delegate_to: "{{first_etcd_host}}"
 
 - name: Gen_certs | write openssl config
   template:
     src: "openssl.conf.j2"
     dest: "{{ etcd_config_dir }}/openssl.conf"
-  run_once: yes
-  delegate_to: "{{first_etcd_host}}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == first_etcd_host
@@ -45,8 +39,6 @@
     src: "make-ssl-etcd.sh.j2"
     dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
     mode: 0700
-  run_once: yes
-  delegate_to: "{{first_etcd_host}}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == first_etcd_host
@@ -64,8 +56,6 @@
                     {{ h }}
                 {% endif %}
               {% endfor %}"
-  run_once: yes
-  delegate_to: "{{first_etcd_host}}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == first_etcd_host

--- a/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
@@ -36,7 +36,7 @@
   when:
     - kubeadm_init is defined
     - kubeadm_init.changed|default(false)
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Delete old KubeDNS resources
   kube:
@@ -64,7 +64,7 @@
   when:
     - kubeadm_init is defined
     - kubeadm_init.changed|default(false)
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Delete old KubeDNS Autoscaler deployment
   kube:

--- a/roles/kubernetes-apps/ansible/tasks/coredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/coredns.yml
@@ -19,7 +19,7 @@
     clusterIP: "{{ skydns_server }}"
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - coredns
 
@@ -37,6 +37,6 @@
     coredns_ordinal_suffix: "-secondary"
   when:
     - dns_mode == 'coredns_dual'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - coredns

--- a/roles/kubernetes-apps/ansible/tasks/dashboard.yml
+++ b/roles/kubernetes-apps/ansible/tasks/dashboard.yml
@@ -17,7 +17,7 @@
   with_items:
     - { file: dashboard.yml, type: deploy, name: kubernetes-dashboard }
   register: manifests
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Start dashboard
   kube:
@@ -28,4 +28,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/ansible/tasks/kubedns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/kubedns.yml
@@ -16,7 +16,7 @@
   register: kubedns_manifests
   when:
     - dns_mode in ['kubedns','dnsmasq_kubedns']
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - dnsmasq
     - kubedns
@@ -36,7 +36,7 @@
              }'
   when:
     - dns_mode in ['kubedns', 'dnsmasq_kubedns']
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - rbac_enabled and kubedns_version is version("1.11.0", "<", strict=True)
   tags:
     - dnsmasq

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -9,12 +9,12 @@
   until: result.status == 200
   retries: 10
   delay: 2
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Cleanup DNS
   import_tasks: tasks/cleanup_dns.yml
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
     - dnsmasq
@@ -26,7 +26,7 @@
   import_tasks: "tasks/coredns.yml"
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - coredns
 
@@ -34,7 +34,7 @@
   import_tasks: "tasks/nodelocaldns.yml"
   when:
     - enable_nodelocaldns == True
-    - inventory_hostname == groups['kube-master'] | first
+    - inventory_hostname == first_kube_master_host
   tags:
     - nodelocaldns
 
@@ -42,7 +42,7 @@
   import_tasks: "tasks/kubedns.yml"
   when:
     - dns_mode in ['kubedns', 'dnsmasq_kubedns']
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - dnsmasq
 
@@ -61,7 +61,7 @@
     - "{{ nodelocaldns_manifests.results | default({}) }}"
   when:
     - dns_mode != 'none'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - not item is skipped
   register: resource_result
   until: resource_result is succeeded

--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -16,7 +16,7 @@
     kubectl: "{{bin_dir}}/kubectl"
     resource: "deploy"
     state: latest
-  when: inventory_hostname == groups['kube-master'][0] and netchecker_server_manifest.stat.exists
+  when: inventory_hostname == first_kube_master_host and netchecker_server_manifest.stat.exists
   tags:
     - upgrade
 
@@ -49,7 +49,7 @@
   with_items: "{{ netchecker_templates }}"
   register: manifests
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Purge old Netchecker server
   kube:
@@ -58,7 +58,7 @@
     kubectl: "{{bin_dir}}/kubectl"
     resource: "po"
     state: absent
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Start Netchecker Resources
   kube:
@@ -69,4 +69,4 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0] and not item is skipped
+  when: inventory_hostname == first_kube_master_host and not item is skipped

--- a/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
@@ -13,6 +13,6 @@
     secondaryclusterIP: "{{ skydns_server_secondary }}"
   when:
     - enable_nodelocaldns == True
-    - inventory_hostname == groups['kube-master'] | first
+    - inventory_hostname == first_kube_master_host
   tags:
     - nodelocaldns

--- a/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
@@ -8,20 +8,20 @@
     src: controller-manager-config.yml.j2
     dest: /tmp/controller-manager-config.yml
   register: controller_manager_config
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   tags: oci
 
 - name: "OCI Cloud Controller | Encode Configuration"
   set_fact:
     controller_manager_config_base64: "{{ lookup('file', '/tmp/controller-manager-config.yml') | b64encode }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   tags: oci
 
 - name: "OCI Cloud Controller | Apply Configuration To Secret"
   template:
     src: cloud-provider.yml.j2
     dest: /tmp/cloud-provider.yml
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   tags: oci
 
 - name: "OCI Cloud Controller | Apply Configuration"
@@ -29,7 +29,7 @@
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "/tmp/cloud-provider.yml"
     state: latest
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   tags: oci
 
 - name: "OCI Cloud Controller | Download Controller Manifest"
@@ -41,7 +41,7 @@
   until: "'OK' in result.msg"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   tags: oci
 
 - name: "OCI Cloud Controller | Apply Controller Manifest"
@@ -49,5 +49,5 @@
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "/tmp/oci-cloud-controller-manager.yml"
     state: latest
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   tags: oci

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -9,14 +9,14 @@
   until: result.status == 200
   retries: 10
   delay: 6
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Check AppArmor status
   command: which apparmor_parser
   register: apparmor_status
   when:
     - podsecuritypolicy_enabled
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   failed_when: false
 
 - name: Kubernetes Apps | Set apparmor_enabled
@@ -24,7 +24,7 @@
     apparmor_enabled: "{{ apparmor_status.rc == 0 }}"
   when:
     - podsecuritypolicy_enabled
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Render templates for PodSecurityPolicy
   template:
@@ -37,7 +37,7 @@
     - {file: psp-crb.yml, type: rolebinding, name: psp-crb}
   when:
     - podsecuritypolicy_enabled
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Add policies, roles, bindings for PodSecurityPolicy
   kube:
@@ -48,7 +48,7 @@
     state: "latest"
   with_items: "{{ psp_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"
@@ -60,7 +60,7 @@
   register: node_crb_manifest
   when:
     - rbac_enabled
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Apply workaround to allow all nodes with cert O=system:nodes to register
   kube:
@@ -72,7 +72,7 @@
   when:
     - rbac_enabled
     - node_crb_manifest.changed
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Apps | Add webhook ClusterRole that grants access to proxy, stats, log, spec, and metrics on a kubelet
   template:
@@ -82,7 +82,7 @@
   when:
     - rbac_enabled
     - kubelet_authorization_mode_webhook
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: node-webhook
 
 - name: Apply webhook ClusterRole
@@ -96,7 +96,7 @@
     - rbac_enabled
     - kubelet_authorization_mode_webhook
     - node_webhook_cr_manifest.changed
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: node-webhook
 
 - name: Kubernetes Apps | Add ClusterRoleBinding for system:nodes to webhook ClusterRole
@@ -107,7 +107,7 @@
   when:
     - rbac_enabled
     - kubelet_authorization_mode_webhook
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: node-webhook
 
 - name: Grant system:nodes the webhook ClusterRole
@@ -121,7 +121,7 @@
     - rbac_enabled
     - kubelet_authorization_mode_webhook
     - node_webhook_crb_manifest.changed
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: node-webhook
 
 - name: Check if vsphere-cloud-provider ClusterRole exists
@@ -134,7 +134,7 @@
     - cloud_provider == 'vsphere'
     - kube_version is version('v1.9.0', '>=')
     - kube_version is version('v1.9.3', '<=')
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: vsphere
 
 - name: Write vsphere-cloud-provider ClusterRole manifest
@@ -150,7 +150,7 @@
     - vsphere_cloud_provider.rc != 0
     - kube_version is version('v1.9.0', '>=')
     - kube_version is version('v1.9.3', '<=')
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: vsphere
 
 - name: Apply vsphere-cloud-provider ClusterRole
@@ -168,7 +168,7 @@
     - vsphere_cloud_provider.rc != 0
     - kube_version is version('v1.9.0', '>=')
     - kube_version is version('v1.9.3', '<=')
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags: vsphere
 
 - include_tasks: oci.yml

--- a/roles/kubernetes-apps/cluster_roles/tasks/oci.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/oci.yml
@@ -11,7 +11,7 @@
   when:
     - cloud_provider is defined
     - cloud_provider == 'oci'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Apply OCI ClusterRole, and ClusterRoleBinding
   kube:
@@ -20,4 +20,4 @@
   when:
     - cloud_provider is defined
     - cloud_provider == 'oci'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
@@ -38,7 +38,7 @@
     - { name: k8s-device-plugin-nvidia-daemonset, file: k8s-device-plugin-nvidia-daemonset.yml, type: daemonset }
   register: container_engine_accelerator_manifests
   when:
-    - inventory_hostname == groups['kube-master'][0] and nvidia_driver_install_container
+    - inventory_hostname == first_kube_master_host and nvidia_driver_install_container
 
 - name: Container Engine Acceleration Nvidia GPU | Apply manifests for nvidia accelerators
   kube:
@@ -51,4 +51,4 @@
   with_items:
     - "{{container_engine_accelerator_manifests.results}}"
   when:
-    - inventory_hostname == groups['kube-master'][0] and nvidia_driver_install_container and nvidia_driver_install_supported
+    - inventory_hostname == first_kube_master_host and nvidia_driver_install_container and nvidia_driver_install_supported

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ kube_config_dir }}/addons/cephfs_provisioner"
     state: absent
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -14,7 +14,7 @@
     {{ bin_dir }}/kubectl delete namespace {{ cephfs_provisioner_namespace }}
   ignore_errors: yes
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -23,7 +23,7 @@
     {{ bin_dir }}/kubectl delete storageclass {{ cephfs_provisioner_storage_class }}
   ignore_errors: yes
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -35,7 +35,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: CephFS Provisioner | Templates list
   set_fact:
@@ -65,7 +65,7 @@
     dest: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.file }}"
   with_items: "{{ cephfs_provisioner_templates }}"
   register: cephfs_provisioner_manifests
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: CephFS Provisioner | Apply manifests
   kube:
@@ -76,4 +76,4 @@
     filename: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ cephfs_provisioner_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -48,7 +48,7 @@
     dest: "{{ kube_config_dir }}/addons/local_volume_provisioner/{{ item.file }}"
   with_items: "{{ local_volume_provisioner_templates }}"
   register: local_volume_provisioner_manifests
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Local Volume Provisioner | Apply manifests
   kube:
@@ -59,6 +59,6 @@
     filename: "{{ kube_config_dir }}/addons/local_volume_provisioner/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ local_volume_provisioner_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
+++ b/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
@@ -1,15 +1,15 @@
 ---
-- name: "Gen_helm_tiller_certs | Create helm config directory (on {{groups['kube-master'][0]}})"
+- name: "Gen_helm_tiller_certs | Create helm config directory (on {{ first_kube_master_host }})"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   file:
     path: "{{ helm_config_dir }}"
     state: directory
     owner: kube
 
-- name: "Gen_helm_tiller_certs | Create helm script directory (on {{groups['kube-master'][0]}})"
+- name: "Gen_helm_tiller_certs | Create helm script directory (on {{ first_kube_master_host }})"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   file:
     path: "{{ helm_script_dir }}"
     state: directory
@@ -17,24 +17,24 @@
 
 - name: Gen_helm_tiller_certs | Copy certs generation script
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   template:
     src: "helm-make-ssl.sh.j2"
     dest: "{{ helm_script_dir }}/helm-make-ssl.sh"
     mode: 0700
 
-- name: "Check_helm_certs | check if helm client certs have already been generated on first master (on {{groups['kube-master'][0]}})"
+- name: "Check_helm_certs | check if helm client certs have already been generated on first master (on {{ first_kube_master_host }})"
   find:
     paths: "{{ helm_home_dir }}"
     patterns: "*.pem"
     get_checksum: true
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   register: helmcert_master
   run_once: true
 
 - name: Gen_helm_tiller_certs | run cert generation script
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   command: "{{ helm_script_dir }}/helm-make-ssl.sh -e {{ helm_home_dir }} -d {{ helm_tiller_cert_dir }}"
 
 - set_fact:
@@ -46,12 +46,12 @@
     patterns: "*.pem"
     get_checksum: true
   register: helmcert_node
-  when: inventory_hostname != groups['kube-master'][0]
+  when: inventory_hostname !=  first_kube_master_host
 
 - name: "Check_helm_client_certs | Set 'sync_helm_certs' to true on masters"
   set_fact:
     sync_helm_certs: true
-  when: inventory_hostname != groups['kube-master'][0] and
+  when: inventory_hostname !=  first_kube_master_host  and
       (not item in helmcert_node.files | map(attribute='path') | map("basename") | list or
       helmcert_node.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != helmcert_master.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
   with_items:
@@ -64,8 +64,8 @@
   no_log: true
   register: helm_client_cert_data
   check_mode: no
-  delegate_to: "{{groups['kube-master'][0]}}"
-  when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
+  delegate_to: "{{ first_kube_master_host }}"
+  when: sync_helm_certs|default(false) and inventory_hostname !=  first_kube_master_host
 
 - name: Gen_helm_tiller_certs | Use tempfile for unpacking certs on masters
   tempfile:
@@ -74,7 +74,7 @@
     prefix: helmcertsXXXXX
     suffix: tar.gz
   register: helm_cert_tempfile
-  when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
+  when: sync_helm_certs|default(false) and inventory_hostname !=  first_kube_master_host
 
 - name: Gen_helm_tiller_certs | Write helm client certs to tempfile
   copy:
@@ -82,20 +82,20 @@
     dest: "{{helm_cert_tempfile.path}}"
     owner: root
     mode: "0600"
-  when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
+  when: sync_helm_certs|default(false) and inventory_hostname !=  first_kube_master_host
 
 - name: Gen_helm_tiller_certs | Unpack helm certs on masters
   shell: "base64 -d < {{ helm_cert_tempfile.path }} | tar xz -C {{ helm_home_dir }}"
   no_log: true
   changed_when: false
   check_mode: no
-  when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
+  when: sync_helm_certs|default(false) and inventory_hostname !=  first_kube_master_host
 
 - name: Gen_helm_tiller_certs | Cleanup tempfile on masters
   file:
     path: "{{helm_cert_tempfile.path}}"
     state: absent
-  when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
+  when: sync_helm_certs|default(false) and inventory_hostname !=  first_kube_master_host
 
 - name: Gen_certs | check certificate permissions
   file:

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -16,7 +16,7 @@
   register: manifests
   when:
     - dns_mode != 'none'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Helm | Apply Helm Manifests (RBAC)
   kube:
@@ -29,7 +29,7 @@
   with_items: "{{ manifests.results }}"
   when:
     - dns_mode != 'none'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 # Generate necessary certs for securing Helm and Tiller connection with TLS
 - name: Helm | Set up TLS
@@ -41,7 +41,7 @@
     {{ bin_dir }}/helm init --tiller-namespace={{ tiller_namespace }}
     {% if helm_skip_refresh %} --skip-refresh{% endif %}
     {% if helm_stable_repo_url is defined %} --stable-repo-url {{ helm_stable_repo_url }}{% endif %}
-    {% if inventory_hostname == groups['kube-master'][0] %}
+    {% if inventory_hostname == first_kube_master_host %}
     --upgrade --tiller-image={{ tiller_image_repo }}:{{ tiller_image_tag }}
     {% if rbac_enabled %} --service-account=tiller{% endif %}
     {% if tiller_node_selectors is defined %} --node-selectors {{ tiller_node_selectors }}{% endif %}
@@ -75,7 +75,7 @@
   changed_when: false
   when:
     - (tiller_override is defined and tiller_override != "") or (kube_version is version('v1.11.1', '>='))
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   environment: "{{proxy_env}}"
 
 - name: Helm | Set up bash completion

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ kube_config_dir }}/addons/cert_manager"
     state: absent
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -14,7 +14,7 @@
     {{ bin_dir }}/kubectl delete namespace {{ cert_manager_namespace }}
   ignore_errors: yes
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -26,7 +26,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Cert Manager | Create manifests
   template:
@@ -43,7 +43,7 @@
     - { name: deploy-cert-manager, file: deploy-cert-manager.yml, type: deploy }
   register: cert_manager_manifests
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Cert Manager | Apply manifests
   kube:
@@ -55,4 +55,4 @@
     state: "latest"
   with_items: "{{ cert_manager_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ kube_config_dir }}/addons/ingress_nginx"
     state: absent
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -14,7 +14,7 @@
     {{ bin_dir }}/kubectl delete namespace {{ ingress_nginx_namespace }}
   ignore_errors: yes
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -26,7 +26,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: NGINX Ingress Controller | Templates list
   set_fact:
@@ -57,7 +57,7 @@
   with_items: "{{ ingress_nginx_templates }}"
   register: ingress_nginx_manifests
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: NGINX Ingress Controller | Apply manifests
   kube:
@@ -69,4 +69,4 @@
     state: "latest"
   with_items: "{{ ingress_nginx_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - role: kubernetes-apps/ansible
     when:
-      - inventory_hostname == groups['kube-master'][0]
+      - inventory_hostname == first_kube_master_host
     tags:
       - apps
 
@@ -16,7 +16,7 @@ dependencies:
   - role: kubernetes-apps/registry
     when:
       - registry_enabled
-      - inventory_hostname == groups['kube-master'][0]
+      - inventory_hostname == first_kube_master_host
     tags:
       - apps
       - registry
@@ -24,7 +24,7 @@ dependencies:
   - role: kubernetes-apps/metrics_server
     when:
       - metrics_server_enabled
-      - inventory_hostname == groups['kube-master'][0]
+      - inventory_hostname == first_kube_master_host
     tags:
       - apps
       - metrics_server
@@ -32,7 +32,7 @@ dependencies:
   - role: kubernetes-apps/persistent_volumes
     when:
       - persistent_volumes_enabled
-      - inventory_hostname == groups['kube-master'][0]
+      - inventory_hostname == first_kube_master_host
     tags:
       - apps
       - persistent_volumes
@@ -47,6 +47,6 @@ dependencies:
     when:
       - cloud_provider is defined
       - cloud_provider == "oci"
-      - inventory_hostname == groups['kube-master'][0]
+      - inventory_hostname == first_kube_master_host
     tags:
       - oci

--- a/roles/kubernetes-apps/metrics_server/tasks/main.yml
+++ b/roles/kubernetes-apps/metrics_server/tasks/main.yml
@@ -9,7 +9,7 @@
     path: "{{ kube_config_dir }}/addons/metrics_server"
     state: absent
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   tags:
     - upgrade
 
@@ -21,7 +21,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Metrics Server | Templates list
   set_fact:
@@ -43,7 +43,7 @@
   with_items: "{{ metrics_server_templates }}"
   register: metrics_server_manifests
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Metrics Server | Apply manifests
   kube:
@@ -54,4 +54,4 @@
     state: "latest"
   with_items: "{{ metrics_server_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/network_plugin/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/calico/tasks/main.yml
@@ -10,13 +10,13 @@
   with_items:
     - "{{ calico_node_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube-master'][0] and not item is skipped
+    - inventory_hostname == first_kube_master_host and not item is skipped
   loop_control:
     label: "{{ item.item.file }}"
 
 - name: "calico upgrade complete"
   shell: "{{ bin_dir }}/calico-upgrade complete --no-prompts --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - calico_upgrade_enabled|default(True)
     - calico_upgrade_needed|default(False)

--- a/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
@@ -8,4 +8,4 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ canal_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0] and not item is skipped
+  when: inventory_hostname == first_kube_master_host and not item is skipped

--- a/roles/kubernetes-apps/network_plugin/cilium/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/cilium/tasks/main.yml
@@ -8,7 +8,7 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ cilium_node_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0] and not item is skipped
+  when: inventory_hostname == first_kube_master_host and not item is skipped
 
 - name: Cilium | Wait for pods to run
   command: "{{bin_dir}}/kubectl -n kube-system get pods -l k8s-app=cilium -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"
@@ -17,4 +17,4 @@
   retries: 30
   delay: 10
   ignore_errors: yes
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
@@ -8,7 +8,7 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ flannel_node_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0] and not item is skipped
+  when: inventory_hostname == first_kube_master_host and not item is skipped
 
 - name: Flannel | Wait for flannel subnet.env file presence
   wait_for:

--- a/roles/kubernetes-apps/network_plugin/kube-router/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/kube-router/tasks/main.yml
@@ -9,7 +9,7 @@
     namespace: "kube-system"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: kube-router | Wait for kube-router pods to be ready
   command: "{{bin_dir}}/kubectl -n kube-system get pods -l k8s-app=kube-router -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"
@@ -19,4 +19,4 @@
   delay: 10
   ignore_errors: yes
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -8,4 +8,4 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ multus_manifest_1.results }} + {{multus_manifest_2.results }}"
-  when: inventory_hostname == groups['kube-master'][0] and not item|skipped
+  when: inventory_hostname == first_kube_master_host and not item|skipped

--- a/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
@@ -8,7 +8,7 @@
     resource: "ds"
     namespace: "kube-system"
     state: "latest"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Weave | Wait for Weave to become available
   uri:
@@ -18,4 +18,4 @@
   retries: 180
   delay: 5
   until: "weave_status.status == 200 and 'Status: ready' in weave_status.content"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host

--- a/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
@@ -5,7 +5,7 @@
     dest: "{{kube_config_dir}}/openstack-storage-class.yml"
   register: manifests
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Kubernetes Persistent Volumes | Add OpenStack Cinder Storage Class
   kube:
@@ -15,5 +15,5 @@
     filename: "{{kube_config_dir}}/openstack-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - manifests.changed

--- a/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
@@ -19,7 +19,7 @@
     - {name: calico-kube-controllers, file: calico-kube-crb.yml, type: clusterrolebinding}
   register: calico_kube_manifests
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - rbac_enabled or item.type not in rbac_resources
 
 - name: Start of Calico kube controllers
@@ -33,7 +33,7 @@
   with_items:
     - "{{ calico_kube_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
   with_items: "{{ registry_templates }}"
   register: registry_manifests
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Registry | Apply manifests
   kube:
@@ -49,7 +49,7 @@
     filename: "{{ kube_config_dir }}/addons/registry/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ registry_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == first_kube_master_host
 
 - name: Registry | Create PVC manifests
   template:
@@ -61,7 +61,7 @@
   when:
     - registry_storage_class != none
     - registry_disk_size != none
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: Registry | Apply PVC manifests
   kube:
@@ -75,4 +75,4 @@
   when:
     - registry_storage_class != none
     - registry_disk_size != none
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -18,14 +18,14 @@
 - name: Calculate kubeadm CA cert hash
   shell: openssl x509 -pubkey -in {{ kube_cert_dir }}/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
   register: kubeadm_ca_hash
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
   command: "{{ bin_dir }}/kubeadm token create"
   run_once: true
   register: temp_token
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
 
 - name: gets the kubeadm version
   command: "{{ bin_dir }}/kubeadm version -o short"
@@ -97,7 +97,7 @@
     {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get configmap kube-proxy -n kube-system -o yaml
     | sed 's#server:.*#server:\ {{ kube_apiserver_endpoint }}#g'
     | {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf replace -f -
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -118,7 +118,7 @@
 
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
   shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy"
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -132,7 +132,7 @@
 # is fixed
 - name: Delete kube-proxy daemonset if kube_proxy_remove set, e.g. kube_network_plugin providing proxy services
   shell: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf delete daemonset -n kube-system kube-proxy"
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   when:
     - kube_proxy_remove

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -3,7 +3,7 @@
   stat:
     path: "{{ kube_cert_dir }}/apiserver.pem"
   register: old_apiserver_cert
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: kubeadm | Migrate old certs if necessary
@@ -14,7 +14,7 @@
   stat:
     path: "{{ kube_cert_dir }}/sa.key"
   register: sa_key_before
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: kubeadm | Check if kubeadm has already run
@@ -131,7 +131,7 @@
   register: kubeadm_init
   # Retry is because upload config sometimes fails
   retries: 3
-  when: inventory_hostname == groups['kube-master']|first and not kubeadm_already_run.stat.exists
+  when: inventory_hostname == first_kube_master_host and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   notify: Master | restart kubelet
 
@@ -149,7 +149,7 @@
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
   retries: 3
-  when: inventory_hostname == groups['kube-master']|first and (kubeadm_config.changed and kubeadm_already_run.stat.exists)
+  when: inventory_hostname == first_kube_master_host and (kubeadm_config.changed and kubeadm_already_run.stat.exists)
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   notify: Master | restart kubelet
 
@@ -170,7 +170,7 @@
     - "{{ kube_cert_dir }}/sa.key"
     - "{{ kube_cert_dir }}/sa.pub"
   register: kubeadm_certs
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: kubeadm | write out kubeadm certs
@@ -183,14 +183,14 @@
   no_log: true
   register: copy_kubeadm_certs
   with_items: "{{ kubeadm_certs.results }}"
-  when: inventory_hostname != groups['kube-master']|first
+  when: inventory_hostname != first_kube_master_host
 
 - name: kubeadm | Init other uninitialized masters
   command: timeout -k 600s 600s {{ bin_dir }}/kubeadm init --config={{ kube_config_dir }}/kubeadm-config.{{ kubeadmConfig_api_version }}.yaml --ignore-preflight-errors=all
   register: kubeadm_init
   retries: 10
   until: kubeadm_init is succeeded or "field is immutable" in kubeadm_init.stderr
-  when: inventory_hostname != groups['kube-master']|first and not kubeadm_already_run.stat.exists
+  when: inventory_hostname != first_kube_master_host and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   notify: Master | restart kubelet
 
@@ -205,7 +205,7 @@
     --allow-release-candidate-upgrades
     --etcd-upgrade=false
   register: kubeadm_upgrade
-  when: inventory_hostname != groups['kube-master']|first and (kubeadm_config.changed and kubeadm_already_run.stat.exists)
+  when: inventory_hostname != first_kube_master_host and (kubeadm_config.changed and kubeadm_already_run.stat.exists)
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   notify: Master | restart kubelet
 
@@ -213,7 +213,7 @@
   stat:
     path: "{{ kube_cert_dir }}/sa.key"
   register: sa_key_after
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: kubeadm | Set secret_changed if service account key was updated
@@ -228,6 +228,6 @@
 
 - name: kubeadm | Remove taint for master with node role
   command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: inventory_hostname in groups['kube-node']
   failed_when: false

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -6,7 +6,7 @@
     ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
     ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
   register: old_data_exists
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ first_etcd_host }}"
   changed_when: false
   when: kube_apiserver_storage_backend == "etcd3"
   failed_when: false

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -139,7 +139,7 @@
   shell: "{{ bin_dir }}/calicoctl version  | grep 'Cluster Version:' | awk '{ print $3}'"
   register: calico_version_on_server
   run_once: yes
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - kube_network_plugin == 'calico'
 
@@ -152,7 +152,7 @@
     - kube_network_plugin == 'calico'
     - 'calico_version_on_server.stdout is defined'
     - 'calico_version_on_server.stdout != ""'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   run_once: yes
 
 - name: "Check that kube_service_addresses is a network range"

--- a/roles/kubernetes/tokens/tasks/check-tokens.yml
+++ b/roles/kubernetes/tokens/tasks/check-tokens.yml
@@ -2,7 +2,7 @@
 - name: "Check_tokens | check if the tokens have already been generated on first master"
   stat:
     path: "{{ kube_token_dir }}/known_tokens.csv"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   register: known_tokens_master
   run_once: true
 

--- a/roles/kubernetes/tokens/tasks/gen_tokens.yml
+++ b/roles/kubernetes/tokens/tasks/gen_tokens.yml
@@ -5,7 +5,7 @@
     dest: "{{ kube_script_dir }}/kube-gen-token.sh"
     mode: 0700
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | generate tokens for master components
@@ -18,7 +18,7 @@
   register: gentoken_master
   changed_when: "'Added' in gentoken_master.stdout"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | generate tokens for node components
@@ -31,14 +31,14 @@
   register: gentoken_node
   changed_when: "'Added' in gentoken_node.stdout"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | Get list of tokens from first master
   shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"
   register: tokens_list
   check_mode: no
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   when: sync_tokens|default(false)
 
@@ -48,11 +48,11 @@
     warn: false
   register: tokens_data
   check_mode: no
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   when: sync_tokens|default(false)
 
 - name: Gen_tokens | Copy tokens on masters
   shell: "echo '{{ tokens_data.stdout|quote }}' | base64 -d | tar xz -C /"
   when: inventory_hostname in groups['kube-master'] and sync_tokens|default(false) and
-        inventory_hostname != groups['kube-master'][0] and tokens_data.stdout != ''
+        inventory_hostname !=  first_kube_master_host and tokens_data.stdout != ''

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -371,12 +371,24 @@ ssl_ca_dirs: >-
   {% endif -%}
   ]
 
+# Enable savvy users to define the first kube master node in a different way
+first_kube_master_host: "{{ groups['kube-master']|first }}"
+
+# Enable savvy users to define the first kube worker node in a different way
+first_kube_worker_host: "{{ groups['kube-node']|first }}"
+
+# Enable savvy users to define the first etcd node in a different way
+first_etcd_host: "{{ groups['etcd']|first }}"
+
+# Enable savvy users to define the first bastion node in a different way
+first_bastion_host: "{{ groups['bastion']|first }}"
+
 # Vars for pointing to kubernetes api endpoints
 is_kube_master: "{{ inventory_hostname in groups['kube-master'] }}"
 kube_apiserver_count: "{{ groups['kube-master'] | length }}"
 kube_apiserver_address: "{{ ip | default(ansible_default_ipv4['address']) }}"
 kube_apiserver_access_address: "{{ access_ip | default(kube_apiserver_address) }}"
-first_kube_master: "{{ hostvars[groups['kube-master'][0]]['access_ip'] | default(hostvars[groups['kube-master'][0]]['ip'] | default(hostvars[groups['kube-master'][0]]['ansible_default_ipv4']['address'])) }}"
+first_kube_master: "{{ hostvars[first_kube_master_host]['access_ip'] | default(hostvars[first_kube_master_host]['ip'] | default(hostvars[first_kube_master_host]['ansible_default_ipv4']['address'])) }}"
 loadbalancer_apiserver_localhost: "{{ loadbalancer_apiserver is not defined }}"
 # applied if only external loadbalancer_apiserver is defined, otherwise ignored
 apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"

--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -57,11 +57,11 @@
      }'
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
-    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ first_etcd_host }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ first_etcd_host }}-key.pem"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ first_etcd_host }}"
   when:
     - calico_version is version("v3.0.0", ">=")
 
@@ -75,11 +75,11 @@
        "cluster_id": "{{ cluster_id }}"
      }'
   environment:
-    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
-    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ first_etcd_host }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ first_etcd_host }}-key.pem"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ first_etcd_host }}"
   when:
     - calico_version is version("v3.0.0", "<")
 

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -13,7 +13,7 @@
   shell: "{{ bin_dir }}/calicoctl version  | grep 'Cluster Version:' | awk '{ print $3}'"
   register: calico_version_on_server
   run_once: yes
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
 
 - name: "Determine if calico upgrade is needed"
   block:
@@ -34,5 +34,5 @@
   when:
     - 'calico_version_on_server.stdout is defined'
     - 'calico_version_on_server.stdout != ""'
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   run_once: yes

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -79,7 +79,7 @@
   register: calico_conf
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Calico | Configure calico network pool
@@ -95,7 +95,7 @@
           "ipipMode": "{{ ipip_mode }}",
           "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl create -f -
   run_once: true
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - 'calico_conf.stdout == "0"'
     - calico_version is version("v3.0.0", ">=")
@@ -112,7 +112,7 @@
   environment:
     NO_DEFAULT_POOLS: true
   run_once: true
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - 'calico_conf.stdout == "0"'
     - calico_version is version("v3.0.0", "<")
@@ -138,7 +138,7 @@
         "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
         "asNumber": {{ global_as_num }} }} ' | {{ bin_dir }}/calicoctl create --skip-exists -f -
   run_once: true
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - calico_version is version('v3.0.0', '>=')
 

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -8,6 +8,6 @@
     - calico_upgrade_enabled
     - calico_upgrade_needed
   run_once: yes
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
 
 - include_tasks: install.yml

--- a/roles/network_plugin/calico/tasks/pre.yml
+++ b/roles/network_plugin/calico/tasks/pre.yml
@@ -11,6 +11,6 @@
     {{ bin_dir }}/kubectl get node -o custom-columns='NAME:.metadata.name,INTERNAL-IP:.status.addresses[?(@.type=="InternalIP")].address'
     | egrep "{{ ansible_all_ipv4_addresses | join('$|') }}$" | cut -d" " -f1
   register: calico_kubelet_name
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - "cloud_provider is defined"

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -31,12 +31,12 @@
     '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "{{ flannel_backend_type }}" } }'
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ first_etcd_host }}"
   changed_when: false
   run_once: true
   environment:
-    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
-    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ first_etcd_host }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ first_etcd_host }}-key.pem"
 
 - name: Canal | Create canal node manifests
   template:

--- a/roles/network_plugin/contiv/tasks/main.yml
+++ b/roles/network_plugin/contiv/tasks/main.yml
@@ -94,7 +94,7 @@
   when:
     - contiv_enable_api_proxy
     - contiv_generate_certificate
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Contiv | Check for cert key existence
@@ -104,7 +104,7 @@
   when:
     - contiv_enable_api_proxy
     - contiv_generate_certificate
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Contiv | Generate contiv-api-proxy certificates
@@ -113,7 +113,7 @@
     - contiv_enable_api_proxy
     - contiv_generate_certificate
     - (not contiv_certificate_key_state.stat.exists)
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Contiv | Fetch the generated certificate
@@ -127,7 +127,7 @@
   when:
     - contiv_enable_api_proxy
     - contiv_generate_certificate
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
 
 - name: Contiv | Copy the generated certificate on nodes
@@ -138,7 +138,7 @@
     - auth_proxy_key.pem
     - auth_proxy_cert.pem
   when:
-    - inventory_hostname != groups['kube-master'][0]
+    - inventory_hostname != first_kube_master_host
     - inventory_hostname in groups['kube-master']
     - contiv_enable_api_proxy
     - contiv_generate_certificate

--- a/roles/network_plugin/contiv/tasks/pre-reset.yml
+++ b/roles/network_plugin/contiv/tasks/pre-reset.yml
@@ -19,7 +19,7 @@
     - network
   when:
     - contiv_kubectl.stat.exists
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: reset | Copy contiv temporary cleanup script
   copy:
@@ -38,7 +38,7 @@
   register: contiv_cleanup_manifest
   when:
     - contiv_kubectl.stat.exists
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
 
 - name: reset | Start contiv cleanup resources
   kube:
@@ -50,7 +50,7 @@
     filename: "{{ kube_config_dir }}/contiv-cleanup.yml"
   when:
     - contiv_kubectl.stat.exists
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host
   ignore_errors: true
 
 - name: reset | Wait until contiv cleanup is done
@@ -63,4 +63,4 @@
   changed_when: false
   when:
     - contiv_kubectl.stat.exists
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == first_kube_master_host

--- a/roles/network_plugin/kube-router/tasks/annotate.yml
+++ b/roles/network_plugin/kube-router/tasks/annotate.yml
@@ -3,19 +3,19 @@
   command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_master }}"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: kube_router_annotations_master is defined and inventory_hostname in groups['kube-master']
 
 - name: kube-router | Add annotations on kube-node
   command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_node }}"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: kube_router_annotations_node is defined and inventory_hostname in groups['kube-node']
 
 - name: kube-router | Add common annotations on all servers
   command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_all }}"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: kube_router_annotations_all is defined and inventory_hostname in groups['all']

--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -4,6 +4,6 @@
   command: "{{ bin_dir}}/kubectl delete node {{ item }}"
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   ignore_errors: yes

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -11,6 +11,6 @@
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   failed_when: false
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: true
   ignore_errors: yes

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Uncordon node
   command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ inventory_hostname }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - needs_cordoning|default(false)

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -6,7 +6,7 @@
      {{ bin_dir }}/kubectl get node {{ inventory_hostname }}
      -o jsonpath='{ range .status.conditions[?(@.type == "Ready")].status }{ @ }{ end }'
   register: kubectl_node_ready
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   failed_when: false
   changed_when: false
 
@@ -17,7 +17,7 @@
      {{ bin_dir }}/kubectl get node {{ inventory_hostname }}
      -o jsonpath='{ .spec.unschedulable }'
   register: kubectl_node_schedulable
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   failed_when: false
   changed_when: false
 
@@ -31,13 +31,13 @@
 
 - name: Cordon node
   command: "{{ bin_dir }}/kubectl cordon {{ inventory_hostname }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when: needs_cordoning
 
 - name: Check kubectl version
   command: "{{ bin_dir }}/kubectl version --client --short"
   register: kubectl_version
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   run_once: yes
   changed_when: false
   when:
@@ -62,7 +62,7 @@
     --timeout {{ drain_timeout }}
     --delete-local-data {{ inventory_hostname }}
     {% if drain_pod_selector != "" %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ first_kube_master_host }}"
   when:
     - drain_nodes
     - needs_cordoning

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -25,7 +25,7 @@
 
     - name: Wait for netchecker server
       shell: "{{ bin_dir }}/kubectl get pods --namespace {{netcheck_namespace}} | grep ^netchecker-server"
-      delegate_to: "{{groups['kube-master'][0]}}"
+      delegate_to: "{{ first_kube_master_host }}"
       run_once: true
       register: ncs_pod
       until: ncs_pod.stdout.find('Running') != -1
@@ -35,7 +35,7 @@
     - name: Wait for netchecker agents
       shell: "{{ bin_dir }}/kubectl get pods --namespace {{netcheck_namespace}} | grep '^netchecker-agent-.*Running'"
       run_once: true
-      delegate_to: "{{groups['kube-master'][0]}}"
+      delegate_to: "{{ first_kube_master_host }}"
       register: nca_pod
       until: nca_pod.stdout_lines|length >= groups['kube-node']|intersect(play_hosts)|length * 2
       retries: 3
@@ -44,7 +44,7 @@
     - name: Get netchecker agents
       uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/agents/ return_content=yes
       run_once: true
-      delegate_to: "{{groups['kube-master'][0]}}"
+      delegate_to: "{{ first_kube_master_host }}"
       register: agents
       retries: 18
       delay: "{{ agent_report_interval }}"
@@ -60,7 +60,7 @@
 
     - name: Check netchecker status
       uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/connectivity_check status_code=200 return_content=yes
-      delegate_to: "{{groups['kube-master'][0]}}"
+      delegate_to: "{{ first_kube_master_host }}"
       run_once: true
       register: result
       retries: 3
@@ -74,7 +74,7 @@
       failed_when: not result is success
       run_once: true
       when: not agents.content == '{}'
-      delegate_to: "{{groups['kube-master'][0]}}"
+      delegate_to: "{{ first_kube_master_host }}"
 
     - debug: msg="Cannot get reports from agents, consider as PASSING"
       run_once: true


### PR DESCRIPTION
This enables a more deterministic choice of the first element of the different groups when additional information is available. For example:

```
first_kube_master_host: '{{ groups["kube-master"] | map("extract", hostvars) | list | json_query("[*] | sort_by(@, &openstack.created ) | [*].inventory_hostname") | first }}'
```

This ensures when using the openstack inventory plugin that the oldest kube master is chosen as the "first", which is necessary when replacing the node that would otherwise be first since many kubespray operations treat the "first" master or etcd host specially, coping existing certificate and other files from it.