### PR TITLE
K8S-2085 - Use Calico instead of Canal by default

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -67,7 +67,10 @@ module "compute" {
   etcd_anti_affinity                           = "${var.etcd_anti_affinity}"
   master_anti_affinity                         = "${var.master_anti_affinity}"
   openstack_user_data                          = "${var.openstack_user_data}"
-
+  cluster_cidr                                 = "${var.cluster_cidr}"
+  service_cidr                                 = "${var.service_cidr}"
+  subnet_cidr                                  = "${var.subnet_cidr}"
+  real_network_id                              = "${var.neutron_vlan_enabled != "0" ? module.network.vxlan_network_id : module.network.vlan_network_id}"
 }
 
 module "loadbalancer" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -71,6 +71,7 @@ module "compute" {
   service_cidr                                 = "${var.service_cidr}"
   subnet_cidr                                  = "${var.subnet_cidr}"
   real_network_id                              = "${var.neutron_vlan_enabled != "0" ? module.network.vlan_network_id : module.network.vxlan_network_id }"
+  vip_subnet_id                                = "${module.network.subnet_id}"
 }
 
 module "loadbalancer" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -70,7 +70,7 @@ module "compute" {
   cluster_cidr                                 = "${var.cluster_cidr}"
   service_cidr                                 = "${var.service_cidr}"
   subnet_cidr                                  = "${var.subnet_cidr}"
-  real_network_id                              = "${var.neutron_vlan_enabled != "0" ? module.network.vxlan_network_id : module.network.vlan_network_id}"
+  real_network_id                              = "${var.neutron_vlan_enabled != "0" ? module.network.vlan_network_id : module.network.vxlan_network_id }"
 }
 
 module "loadbalancer" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,5 +1,5 @@
 provider "openstack" {
-  version = "1.5.0"
+  version = "1.15.1"
   use_octavia = "true"
 }
 

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -179,9 +179,6 @@ resource "openstack_networking_port_v2" "k8s_master_no_etcd" {
 
   allowed_address_pairs = [
     { ip_address = "${var.service_cidr}" },
-  ]
-
-  allowed_address_pairs = [
     { ip_address = "${var.cluster_cidr}" },
   ]
 }
@@ -359,9 +356,6 @@ resource "openstack_networking_port_v2" "k8s_node_no_floating_ip" {
 
   allowed_address_pairs = [
     { ip_address = "${var.service_cidr}" },
-  ]
-
-  allowed_address_pairs = [
     { ip_address = "${var.cluster_cidr}" },
   ]
 }

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -162,7 +162,7 @@ resource "openstack_networking_port_v2" "k8s_master_no_etcd" {
   admin_state_up = "true"
   network_id     = "${var.real_network_id}"
 
-  security_groups_ids = ["${openstack_networking_secgroup_v2.k8s_master.id}",
+  security_group_ids = ["${openstack_networking_secgroup_v2.k8s_master.id}",
     "${openstack_networking_secgroup_v2.bastion.id}",
     "${openstack_networking_secgroup_v2.k8s.id}",
     "${openstack_networking_secgroup_v2.k8s-global.id}",
@@ -335,7 +335,7 @@ resource "openstack_networking_port_v2" "k8s_node_no_floating_ip" {
   admin_state_up = "true"
   network_id     = "${var.real_network_id}"
 
-  security_groups_ids = ["${openstack_networking_secgroup_v2.k8s.id}",
+  security_group_ids = ["${openstack_networking_secgroup_v2.k8s.id}",
     "${openstack_networking_secgroup_v2.worker.id}",
     "${openstack_networking_secgroup_v2.k8s-global.id}",
     "${data.openstack_networking_secgroup_v2.default.id}",

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -169,13 +169,13 @@ resource "openstack_networking_port_v2" "k8s_master_no_etcd" {
     "${data.openstack_networking_secgroup_v2.default.id}",
   ]
 
-  allowed_address_pairs = {
-    ip_address = "${var.service_cidr}"
-  }
+  allowed_address_pairs = [
+    { ip_address = "${var.service_cidr}" },
+  ]
 
-  allowed_address_pairs = {
-    ip_address = "${var.cluster_cidr}"
-  }
+  allowed_address_pairs = [
+    { ip_address = "${var.cluster_cidr}" },
+  ]
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
@@ -341,13 +341,13 @@ resource "openstack_networking_port_v2" "k8s_node_no_floating_ip" {
     "${data.openstack_networking_secgroup_v2.default.id}",
   ]
 
-  allowed_address_pairs = {
-    ip_address = "${var.service_cidr}"
-  }
+  allowed_address_pairs = [
+    { ip_address = "${var.service_cidr}" },
+  ]
 
-  allowed_address_pairs = {
-    ip_address = "${var.cluster_cidr}"
-  }
+  allowed_address_pairs = [
+    { ip_address = "${var.cluster_cidr}" },
+  ]
 }
 
 resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -101,3 +101,5 @@ variable "service_cidr" {}
 variable "cluster_cidr" {}
 
 variable "real_network_id" {}
+
+variable "vip_subnet_id" {}

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -93,3 +93,11 @@ variable "master_anti_affinity" {
 variable "openstack_user_data" {
   default = ""
 }
+
+variable "subnet_cidr" {}
+
+variable "service_cidr" {}
+
+variable "cluster_cidr" {}
+
+variable "real_network_id" {}

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -14,3 +14,11 @@ output "subnet_id" {
 output "network_name" {
   value = "${local.network_name}"
 }
+
+output "network_id_vlan" {
+  value = "${element(concat(openstack_networking_network_v2.k8s_vlan_network.*.id, list("")), 0)}"
+}
+
+output "network_id_vxlan" {
+  value = "${element(concat(openstack_networking_network_v2.k8s_vxlan_network.*.id, list("")), 0)}"
+}

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -15,10 +15,10 @@ output "network_name" {
   value = "${local.network_name}"
 }
 
-output "network_id_vlan" {
-  value = "${element(concat(openstack_networking_network_v2.k8s_vlan_network.*.id, list("")), 0)}"
+output "vlan_network_id" {
+  value = "${element(concat(data.openstack_networking_network_v2.k8s_vlan_network.*.id, list("")), 0)}"
 }
 
-output "network_id_vxlan" {
+output "vxlan_network_id" {
   value = "${element(concat(openstack_networking_network_v2.k8s_vxlan_network.*.id, list("")), 0)}"
 }

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -210,3 +210,11 @@ variable "master_anti_affinity" {
 variable "openstack_user_data" {
   default = ""
 }
+
+variable "service_cidr" {
+  default = ""
+}
+
+variable "cluster_cidr" {
+  default = ""
+}

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -19,7 +19,8 @@ Some variables of note include:
 * *docker_version* - Specify version of Docker to used (should be quoted
   string)
 * *etcd_version* - Specify version of ETCD to use
-* *ipip* - Enables Calico ipip encapsulation by default
+* *ipip* - Enables Calico ipip encapsulation by default, only works on Calico < 3.0.0 (bool, default true)
+* *ipip_mode* - Sets Calico ipip mode, only works on Calico >= 3.0.0 (valid values: "CrossSubnet", "Always", "Never")
 * *kube_network_plugin* - Sets k8s network plugin (default Calico)
 * *kube_proxy_mode* - Changes k8s proxy mode to iptables mode
 * *kube_version* - Specify a given Kubernetes hyperkube version

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -22,7 +22,7 @@ global_as_num: "64512"
 # You can set MTU value here. If left undefined or empty, it will
 # not be specified in calico CNI config, so Calico will use built-in
 # defaults. The value should be a number, not a string.
-# calico_mtu: 1500
+calico_mtu: 1400
 
 # Limits for apps
 calico_node_memory_limit: 500M

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -22,7 +22,7 @@ global_as_num: "64512"
 # You can set MTU value here. If left undefined or empty, it will
 # not be specified in calico CNI config, so Calico will use built-in
 # defaults. The value should be a number, not a string.
-calico_mtu: 1400
+# calico_mtu: 1500
 
 # Limits for apps
 calico_node_memory_limit: 500M


### PR DESCRIPTION
These are the kubespray changes to be applies along with: https://github.com/rcbops/mk8s/pull/972 in kaasctl.
