### PR TITLE
Added a flag to include an additional listen metrics url

### DIFF
--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -20,5 +20,5 @@
 {% if etcd_ionice is defined %}
   /bin/ionice {{ etcd_ionice }} \
 {% endif %}
-  /usr/local/bin/etcd \
+  /usr/local/bin/etcd --listen-metrics-urls=http://0.0.0.0:9379 \
   "$@"


### PR DESCRIPTION
There is an issue in establishing communication between etcd endpoints and monitoring prometheus to do queries to the /metrics endpoint.

So, this change adds/exposes an additional url to be used as url for metrics queries.

This is related to this issue:
rackerlabs/kaas#1886

and to this PR:
rackerlabs/kaas#1985