### PR TITLE
update expand_persistent_volumes to true to set allowVolumeExpansion

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -296,7 +296,7 @@ cephfs_provisioner_enabled: false
 rbd_provisioner_enabled: false
 ingress_nginx_enabled: false
 cert_manager_enabled: false
-expand_persistent_volumes: false
+expand_persistent_volumes: true
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 # openstack_blockstorage_version: "v1/v2/auto (default)"


### PR DESCRIPTION
To have `allowVolumeExpansion: true` we need to set `expand_persistent_volumes: true` in the kubespray defaults file.